### PR TITLE
update makefile to automatically install dev dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test: dev_deps
 	PYTHONWARNINGS=default pytest tests.py
 
 .PHONY: test-with-coverage
-test-with-coverage:
+test-with-coverage: dev_deps
 	PYTHONWARNINGS=default pytest --cov=greenstalk tests.py
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test
-test:
+test: dev_deps
 	PYTHONWARNINGS=default pytest tests.py
 
 .PHONY: test-with-coverage
@@ -21,3 +21,6 @@ html-docs:
 .PHONY: clean
 clean:
 	rm -rf .cache/ .coverage *.egg-info/ __pycache__/ **/*/__pycache__/ .tox/ .mypy_cache/ docs/_build/ .pytest_cache/ build/
+
+dev_deps:
+	pip install -r requirements-dev.txt%  


### PR DESCRIPTION
update makefile to automatically install dev dependencies when running unit_tests

1. Added new makefile target `dev_deps` to run `pip install`
2. Modified test to depend on `dev_deps`